### PR TITLE
Manager name not updated on foreman provider edit

### DIFF
--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -20,7 +20,7 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
 
   delegate :api_cached?, :ensure_api_cached, :to => :connect
 
-  before_create :ensure_managers
+  before_validation :ensure_managers
 
   validates :name, :presence => true, :uniqueness => true
   validates :url,  :presence => true

--- a/spec/models/manageiq/providers/foreman/provider_spec.rb
+++ b/spec/models/manageiq/providers/foreman/provider_spec.rb
@@ -58,4 +58,15 @@ describe ManageIQ::Providers::Foreman::Provider do
       expect(CustomizationScript.count).to   eq(0)
     end
   end
+
+  describe "#save" do
+    it "will update the name for the manager" do
+      provider = FactoryGirl.create(:provider_foreman, :zone => FactoryGirl.create(:zone), :name => 'Old Name')
+      expect(provider.configuration_manager.name).to eq('Old Name Configuration Manager')
+
+      provider.update(:name => 'New Name')
+      expect(provider.configuration_manager.name).to eq('New Name Configuration Manager')
+      expect(provider.provisioning_manager.name).to eq('New Name Provisioning Manager')
+    end
+  end
 end


### PR DESCRIPTION
Manager name not updated on foreman provider edit

https://bugzilla.redhat.com/show_bug.cgi?id=1450457