### PR TITLE
Uncomment cassette_library_dir

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,9 @@ if ENV['CI']
   SimpleCov.start
 end
 
-# Uncomment in case you use vcr cassettes
-#VCR.configure do |config|
-#  config.ignore_hosts 'codeclimate.com' if ENV['CI']
-#  config.cassette_library_dir = File.join(ManageIQ::Providers::Foreman::Engine.root, 'spec/vcr_cassettes')
-#end
+VCR.configure do |config|
+  config.ignore_hosts 'codeclimate.com' if ENV['CI']
+  config.cassette_library_dir = File.join(ManageIQ::Providers::Foreman::Engine.root, 'spec/vcr_cassettes')
+end
 
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
Use the cassette_library_dir for foreman tests that use VCR

Cassettes for the `manageiq-provider-foreman` gem were still being referenced from `manageiq`

Allowing them to use their own local directory by uncommenting the `cassette_library_dir` VCR config setting.

Fixes https://github.com/ManageIQ/manageiq-providers-foreman/issues/6

