### PR TITLE
Migrate model display names from locale/en.yml to plugin

### DIFF
--- a/app/models/manageiq/providers/foreman/configuration_manager.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager.rb
@@ -27,4 +27,8 @@ class ManageIQ::Providers::Foreman::ConfigurationManager < ManageIQ::Providers::
   def image_name
     "foreman_configuration"
   end
+
+  def self.display_name(number = 1)
+    n_('Configuration Manager (Foreman)', 'Configuration Managers (Foreman)', number)
+  end
 end

--- a/app/models/manageiq/providers/foreman/configuration_manager/configured_system.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager/configured_system.rb
@@ -28,6 +28,10 @@ class ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem < ::C
     true
   end
 
+  def self.display_name(number = 1)
+    n_('Configured System (Foreman)', 'Configured Systems (Foreman)', number)
+  end
+
   private
 
   def connection_source(options = {})


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/ManageIQ/manageiq/pull/16596 where we want to migrate display model names from locale/en.yml into particular models, where we'll use standard gettext. Main goal here is to make this one aspect of our application pluggable.

Core PR: https://github.com/ManageIQ/manageiq/pull/16836