### PR TITLE
Add 100 seconds as connection timeout to return sooner than apache

### DIFF
--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -32,6 +32,7 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
       :base_url   => base_url,
       :username   => username,
       :password   => password,
+      :timeout    => 100,
       :verify_ssl => verify_ssl
     )
   end

--- a/spec/models/manageiq/providers/foreman/provider_spec.rb
+++ b/spec/models/manageiq/providers/foreman/provider_spec.rb
@@ -3,7 +3,7 @@ require "foreman_api_client"
 describe ManageIQ::Providers::Foreman::Provider do
   let(:provider) { FactoryGirl.build(:provider_foreman) }
   let(:attrs) do
-    {:base_url => "example.com", :username => "admin", :password => "smartvm", :verify_ssl => OpenSSL::SSL::VERIFY_PEER}
+    {:base_url => "example.com", :username => "admin", :password => "smartvm", :timeout => 100, :verify_ssl => OpenSSL::SSL::VERIFY_PEER}
   end
 
   describe "#connect" do


### PR DESCRIPTION
When validating against foreman provider with a closed TCP port, the connection timeout is higher than in Apache and instead of returning with the timeout issue, the server fails with a proxy error. The right solution would be to rewrite the provider validation to be asynchronous, however, with the current implementation it is not possible. There are people working on a complete rewrite of the add/edit provider forms but it's a lot of work and we need this fix ASAP.

I know this is a really ugly way to fix this problem, but the provider forms are far worse :cry: 

@miq-bot add_label gaprindashvili/yes, bug
@miq-bot add_reviewer @mzazrivec 
@miq-bot add_reviewer @martinpovolny 

https://bugzilla.redhat.com/show_bug.cgi?id=1564601