### PR TITLE
Disable UI/API support for creation

### DIFF
--- a/app/models/manageiq/providers/foreman/provisioning_manager.rb
+++ b/app/models/manageiq/providers/foreman/provisioning_manager.rb
@@ -21,4 +21,8 @@ class ManageIQ::Providers::Foreman::ProvisioningManager < ManageIQ::Providers::P
   def self.description
     @description ||= "Foreman Provisioning".freeze
   end
+
+  def self.supported_for_create?
+    false
+  end
 end


### PR DESCRIPTION
Disable creation of the provisioning manager for creation through the
UI/API as this is a "child" manager but doesn't have a parent_manager
because it belongs to a parent provider.  This is unique so we have to
handle this differently.