### PR TITLE
Fix for new foreman factory url generation

### DIFF
--- a/spec/models/manageiq/providers/foreman/provider_spec.rb
+++ b/spec/models/manageiq/providers/foreman/provider_spec.rb
@@ -3,7 +3,7 @@ require "foreman_api_client"
 describe ManageIQ::Providers::Foreman::Provider do
   let(:provider) { FactoryBot.build(:provider_foreman) }
   let(:attrs) do
-    {:base_url => "example.com", :username => "admin", :password => "smartvm", :timeout => 100, :verify_ssl => OpenSSL::SSL::VERIFY_PEER}
+    {:base_url => provider.url, :username => "admin", :password => "smartvm", :timeout => 100, :verify_ssl => OpenSSL::SSL::VERIFY_PEER}
   end
 
   describe "#connect" do


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/19083 changed the foreman
provider factory to sequence the url which is causing spec failures.