### PR TITLE
Add params_for_create and verify_credentials

### DIFF
--- a/app/models/manageiq/providers/foreman/configuration_manager.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager.rb
@@ -16,6 +16,12 @@ class ManageIQ::Providers::Foreman::ConfigurationManager < ManageIQ::Providers::
            :with_provider_connection,
            :to => :provider
 
+  class << self
+    delegate :params_for_create,
+             :verify_credentials,
+             :to => ManageIQ::Providers::Foreman::Provider
+  end
+
   def self.ems_type
     @ems_type ||= "foreman_configuration".freeze
   end

--- a/app/models/manageiq/providers/foreman/provisioning_manager.rb
+++ b/app/models/manageiq/providers/foreman/provisioning_manager.rb
@@ -11,6 +11,12 @@ class ManageIQ::Providers::Foreman::ProvisioningManager < ManageIQ::Providers::P
            :with_provider_connection,
            :to => :provider
 
+  class << self
+    delegate :params_for_create,
+             :verify_credentials,
+             :to => ManageIQ::Providers::Foreman::Provider
+  end
+
   has_many :configuration_locations,    :foreign_key => :provisioning_manager_id
   has_many :configuration_organizations, :foreign_key => :provisioning_manager_id
 


### PR DESCRIPTION
Add a method to return the needed parameters to add a foreman provider
and a method to verify credentials with these parametes.

https://github.com/ManageIQ/manageiq/issues/18818