### PR TITLE
Foreman provider should allow creation in maintenance zone

### DIFF
--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -126,11 +126,16 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
   def ensure_managers
     build_provisioning_manager unless provisioning_manager
     provisioning_manager.name    = "#{name} Provisioning Manager"
-    provisioning_manager.zone_id = zone_id
 
     build_configuration_manager unless configuration_manager
     configuration_manager.name    = "#{name} Configuration Manager"
-    configuration_manager.zone_id = zone_id
+
+    if zone_id_changed?
+      provisioning_manager.enabled = Zone.maintenance_zone&.id != zone_id
+      provisioning_manager.zone_id = zone_id
+      configuration_manager.enabled = Zone.maintenance_zone&.id != zone_id
+      configuration_manager.zone_id = zone_id
+    end
   end
 
   def self.refresh_ems(provider_ids)

--- a/spec/models/manageiq/providers/foreman/provider_spec.rb
+++ b/spec/models/manageiq/providers/foreman/provider_spec.rb
@@ -85,18 +85,18 @@ describe ManageIQ::Providers::Foreman::Provider do
 
     it "sets the provisioning and configuration manager to disabled if created in the maintenance zone" do
       provider = FactoryBot.create(:provider_foreman, :zone => Zone.maintenance_zone)
-      expect(provider.provisioning_manager.enabled).to eql(false)
-      expect(provider.configuration_manager.enabled).to eql(false)
-      expect(provider.provisioning_manager.zone).to eql(Zone.maintenance_zone)
-      expect(provider.configuration_manager.zone).to eql(Zone.maintenance_zone)
+      expect(provider.provisioning_manager.enabled).to eq(false)
+      expect(provider.configuration_manager.enabled).to eq(false)
+      expect(provider.provisioning_manager.zone).to eq(Zone.maintenance_zone)
+      expect(provider.configuration_manager.zone).to eq(Zone.maintenance_zone)
     end
 
     it "sets the provisioning and configuration manager to enabled if not created in the maintenance zone" do
       provider = FactoryBot.create(:provider_foreman, :zone => Zone.default_zone)
-      expect(provider.provisioning_manager.enabled).to eql(true)
-      expect(provider.configuration_manager.enabled).to eql(true)
-      expect(provider.provisioning_manager.zone).to eql(Zone.default_zone)
-      expect(provider.configuration_manager.zone).to eql(Zone.default_zone)
+      expect(provider.provisioning_manager.enabled).to eq(true)
+      expect(provider.configuration_manager.enabled).to eq(true)
+      expect(provider.provisioning_manager.zone).to eq(Zone.default_zone)
+      expect(provider.configuration_manager.zone).to eq(Zone.default_zone)
     end
   end
 end


### PR DESCRIPTION
Currently you cannot create a Foreman provider in the maintenance zone. Instead, this should be legal, though with the provision and configuration managers disabled.

Similar to https://github.com/ManageIQ/manageiq/pull/19947