### PR TITLE
Delegate endpoints and authentications on managers to the provider

### DIFF
--- a/app/models/manageiq/providers/foreman/configuration_manager.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager.rb
@@ -10,7 +10,9 @@ class ManageIQ::Providers::Foreman::ConfigurationManager < ManageIQ::Providers::
   delegate :authentication_check,
            :authentication_status,
            :authentication_status_ok?,
+           :authentications,
            :connect,
+           :endpoints,
            :verify_credentials,
            :with_provider_connection,
            :to => :provider

--- a/app/models/manageiq/providers/foreman/provisioning_manager.rb
+++ b/app/models/manageiq/providers/foreman/provisioning_manager.rb
@@ -4,7 +4,9 @@ class ManageIQ::Providers::Foreman::ProvisioningManager < ManageIQ::Providers::P
   delegate :authentication_check,
            :authentication_status,
            :authentication_status_ok?,
+           :authentications,
            :connect,
+           :endpoints,
            :verify_credentials,
            :with_provider_connection,
            :to => :provider

--- a/spec/models/manageiq/providers/foreman/configuration_manager_spec.rb
+++ b/spec/models/manageiq/providers/foreman/configuration_manager_spec.rb
@@ -1,7 +1,7 @@
 describe ManageIQ::Providers::Foreman::ConfigurationManager do
-  let(:provider) { FactoryBot.build(:provider_foreman) }
+  let(:provider) { configuration_manager.provider }
   let(:configuration_manager) do
-    FactoryBot.build(:configuration_manager_foreman, :provider => provider)
+    FactoryBot.build(:configuration_manager_foreman)
   end
 
   describe "#connect" do


### PR DESCRIPTION
This will allow us to ask for the endpoints/authentications the same way through the API as we do with other providers.

@agrare should we also do this delegation in the prov manager?

Parent issues:
https://github.com/ManageIQ/manageiq/issues/18818
https://github.com/ManageIQ/manageiq/issues/19992