### PR TITLE
Replace SSL verification checkbox with a dropdown in the DDF

### DIFF
--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -51,9 +51,21 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
                   :validate   => [{:type => "required-validator"}]
                 },
                 {
-                  :component => "checkbox",
-                  :name      => "endpoints.default.verify_ssl",
-                  :label     => _("Verify Peer Certificate")
+                  :component    => "select-field",
+                  :name         => "endpoints.default.verify_ssl",
+                  :label        => _("SSL verification"),
+                  :isRequired   => true,
+                  :initialValue => OpenSSL::SSL::VERIFY_PEER,
+                  :options      => [
+                    {
+                      :label => _('Do not verify'),
+                      :value => OpenSSL::SSL::VERIFY_NONE,
+                    },
+                    {
+                      :label => _('Verify'),
+                      :value => OpenSSL::SSL::VERIFY_PEER,
+                    },
+                  ]
                 },
                 {
                   :component  => "text-field",
@@ -99,7 +111,6 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
     base_url = args.dig("endpoints", "default", "url")
     verify_ssl = args.dig("endpoints", "default", "verify_ssl")
     userid, password = default_authentication&.values_at("userid", "password")
-    verify_ssl = verify_ssl ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
     !!raw_connect(base_url, userid, password, verify_ssl).verify?
   end
 


### PR DESCRIPTION
The DDF checkbox only supports a `true` value and when it's not checked, it doesn't even get submitted with the form. If the SSL verification checkbox value doesn't get submitted, the default value will kick in which makes impossible to set the verification to a `false` value. Instead of this, I am replacing it with a dropdown, that doesn't have this issue.

https://github.com/ManageIQ/manageiq/issues/18818
https://github.com/ManageIQ/manageiq-ui-classic/pull/7047
https://github.com/ManageIQ/manageiq-providers-foreman/pull/62#issuecomment-649437942