### PR TITLE
Don't need to override create_from_params

### DIFF
--- a/app/models/manageiq/providers/foreman/configuration_manager.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager.rb
@@ -37,33 +37,6 @@ class ManageIQ::Providers::Foreman::ConfigurationManager < ManageIQ::Providers::
     @description ||= "Foreman Configuration".freeze
   end
 
-  def self.create_from_params(params, endpoints, authentications)
-    new(params).tap do |ems|
-      endpoints.each { |endpoint| ems.assign_nested_endpoint(endpoint) }
-      authentications.each { |authentication| ems.assign_nested_authentication(authentication) }
-
-      ems.provider.save!
-      ems.save!
-    end
-  end
-
-  def edit_with_params(params, endpoints, authentications)
-    tap do |ems|
-      transaction do
-        # Remove endpoints/attributes that are not arriving in the arguments above
-        ems.endpoints.where.not(:role => nil).where.not(:role => endpoints.map { |ep| ep['role'] }).delete_all
-        ems.authentications.where.not(:authtype => nil).where.not(:authtype => authentications.map { |au| au['authtype'] }).delete_all
-
-        ems.assign_attributes(params)
-        ems.endpoints = endpoints.map(&method(:assign_nested_endpoint))
-        ems.authentications = authentications.map(&method(:assign_nested_authentication))
-
-        ems.provider.save!
-        ems.save!
-      end
-    end
-  end
-
   def provider
     super || ensure_provider
   end


### PR DESCRIPTION
When autosaving the base provider relation we don't need to override
create_from_params and edit_with_params