### PR TITLE
Make the default credentials required in the provider DDF

### DIFF
--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -41,6 +41,7 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
               :id                     => 'authentications.default.valid',
               :name                   => 'authentications.default.valid',
               :skipSubmit             => true,
+              :isRequired             => true,
               :validationDependencies => %w[type zone_id],
               :fields                 => [
                 {


### PR DESCRIPTION
The default behavior for the `async-credentials` component is [changing to be optional](https://github.com/ManageIQ/manageiq-ui-classic/pull/7347), so it has to be explicitly marked as required here.