### PR TITLE
Delegating zone to provider breaks worker_class.where

### DIFF
--- a/app/models/manageiq/providers/foreman/configuration_manager.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager.rb
@@ -15,6 +15,7 @@ class ManageIQ::Providers::Foreman::ConfigurationManager < ManageIQ::Providers::
            :connect,
            :endpoints,
            :endpoints=,
+           :name=,
            :url,
            :url=,
            :verify_credentials,
@@ -22,6 +23,7 @@ class ManageIQ::Providers::Foreman::ConfigurationManager < ManageIQ::Providers::
            :to => :provider
 
   belongs_to :provider, :autosave => true, :dependent => :destroy
+  before_validation :update_provider_zone
 
   class << self
     delegate :params_for_create,
@@ -37,6 +39,10 @@ class ManageIQ::Providers::Foreman::ConfigurationManager < ManageIQ::Providers::
     @description ||= "Foreman Configuration".freeze
   end
 
+  def update_provider_zone
+    provider.zone = zone if zone_id_changed?
+  end
+
   def provider
     super || ensure_provider
   end
@@ -44,8 +50,6 @@ class ManageIQ::Providers::Foreman::ConfigurationManager < ManageIQ::Providers::
   def name
     "#{provider.name} Configuration Manager"
   end
-
-  delegate :name=, :zone, :zone=, :zone_id, :zone_id=, :to => :provider
 
   def image_name
     "foreman_configuration"
@@ -58,6 +62,6 @@ class ManageIQ::Providers::Foreman::ConfigurationManager < ManageIQ::Providers::
   private
 
   def ensure_provider
-    build_provider.tap { |p| p.configuration_manager = self }
+    build_provider(:configuration_manager => self, :zone => zone)
   end
 end

--- a/app/models/manageiq/providers/foreman/provider.rb
+++ b/app/models/manageiq/providers/foreman/provider.rb
@@ -172,7 +172,9 @@ class ManageIQ::Providers::Foreman::Provider < ::Provider
     configuration_manager.provider = self
 
     if zone_id_changed?
+      provisioning_manager.zone     = zone
       provisioning_manager.enabled  = Zone.maintenance_zone&.id != zone_id
+      configuration_manager.zone    = zone
       configuration_manager.enabled = Zone.maintenance_zone&.id != zone_id
     end
   end

--- a/spec/models/manageiq/providers/foreman/configuration_manager/refresh_worker_spec.rb
+++ b/spec/models/manageiq/providers/foreman/configuration_manager/refresh_worker_spec.rb
@@ -1,0 +1,10 @@
+describe ManageIQ::Providers::Foreman::ConfigurationManager::RefreshWorker do
+  describe ".all_ems_in_zone" do
+    let(:zone) { EvmSpecHelper.local_guid_miq_server_zone.last }
+    let!(:ems) { FactoryBot.create(:configuration_manager_foreman, :zone => zone) }
+
+    it "returns the ems" do
+      expect(described_class.all_ems_in_zone).to include(ems)
+    end
+  end
+end


### PR DESCRIPTION
Delegating the zone to the provider breaks the PerEmsWorkerMixin which does worker_class.where(:zone => zone) for all_ems_in_zone

Similiar issue as https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/239