### PR TITLE
Use add_collection_for_manager to set parent properly

### DIFF
--- a/app/models/manageiq/providers/foreman/inventory/persister/foreman.rb
+++ b/app/models/manageiq/providers/foreman/inventory/persister/foreman.rb
@@ -2,36 +2,33 @@ class ManageIQ::Providers::Foreman::Inventory::Persister::Foreman < ManageIQ::Pr
   def initialize_inventory_collections
     add_configuration_collection(:configuration_profiles) { |b| b.add_properties(:attributes_blacklist => %i[configuration_tags_hash]) }
     add_configuration_collection(:configured_systems) { |b| b.add_properties(:attributes_blacklist => %i[configuration_tags_hash]) }
-    add_provisioning_collection(:customization_script_media, :default_value_key => :manager_id)
-    add_provisioning_collection(:customization_script_ptables, :default_value_key => :manager_id)
+    add_provisioning_collection(:customization_script_media)
+    add_provisioning_collection(:customization_script_ptables)
     add_provisioning_collection(:operating_system_flavors)
     add_provisioning_collection(:configuration_locations)
     add_provisioning_collection(:configuration_organizations)
-    add_provisioning_collection(:configuration_architectures, :default_value_key => :manager_id)
-    add_provisioning_collection(:configuration_compute_profiles, :default_value_key => :manager_id)
-    add_provisioning_collection(:configuration_domains, :default_value_key => :manager_id)
-    add_provisioning_collection(:configuration_environments, :default_value_key => :manager_id)
-    add_provisioning_collection(:configuration_realms, :default_value_key => :manager_id)
+    add_provisioning_collection(:configuration_architectures)
+    add_provisioning_collection(:configuration_compute_profiles)
+    add_provisioning_collection(:configuration_domains)
+    add_provisioning_collection(:configuration_environments)
+    add_provisioning_collection(:configuration_realms)
   end
 
   private
 
-  def add_configuration_collection(collection)
-    add_collection(configuration, collection) do |builder|
-      builder.add_properties(:parent => manager.provider.configuration_manager)
-      builder.add_default_values(
-        :manager_id => ->(persister) { persister.manager.provider.configuration_manager.id }
-      )
-      yield builder if block_given?
-    end
+  def add_configuration_collection(collection_name, extra_properties = {}, settings = {}, &block)
+    add_collection_for_manager("configuration", collection_name, extra_properties, settings, &block)
   end
 
-  def add_provisioning_collection(collection, default_value_key: :provisioning_manager_id)
-    add_collection(provisioning, collection) do |builder|
-      builder.add_properties(:parent => manager.provider.provisioning_manager)
-      builder.add_default_values(
-        default_value_key => ->(persister) { persister.manager.provider.provisioning_manager.id }
-      )
-    end
+  def add_provisioning_collection(collection_name, extra_properties = {}, settings = {}, &block)
+    add_collection_for_manager("provisioning", collection_name, extra_properties, settings, &block)
+  end
+
+  def configuration_manager
+    manager.kind_of?(ManageIQ::Providers::ConfigurationManager) ? manager : manager.provider.configuration_manager
+  end
+
+  def provisioning_manager
+    manager.kind_of?(ManageIQ::Providers::ProvisioningManager) ? manager : manager.provider.provisioning_manager
   end
 end


### PR DESCRIPTION
Set the parent in settings so it is picked up correctly for cross-manager refreshes

Fixes https://github.com/ManageIQ/manageiq-cross_repo-tests/runs/6598733995?check_suite_focus=true#step:6:2336

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/21885

Required for:
* https://github.com/ManageIQ/manageiq/pull/21650