### PR TITLE
Bump to foreman_api_client 1.0.2 for ruby 3 support

### DIFF
--- a/manageiq-providers-foreman.gemspec
+++ b/manageiq-providers-foreman.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "foreman_api_client", "~>1.0"
+  spec.add_dependency "foreman_api_client", "~>1.0.2"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
apipie-bindings 0.4.0 was bumped as it added ruby 3 support, which dropped some URI methods such as decode/encode/escape/unescape.

See also https://github.com/ManageIQ/manageiq/pull/21036