### PR TITLE
Drop lib/gem-name.rb in favor of lib/gem/name.rb

### DIFF
--- a/lib/manageiq-providers-foreman.rb
+++ b/lib/manageiq-providers-foreman.rb
@@ -1,2 +1,0 @@
-require "manageiq/providers/foreman/engine"
-require "manageiq/providers/foreman/version"

--- a/lib/manageiq/providers/foreman.rb
+++ b/lib/manageiq/providers/foreman.rb
@@ -1,1 +1,2 @@
 require "manageiq/providers/foreman/engine"
+require "manageiq/providers/foreman/version"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ end
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
-require "manageiq-providers-foreman"
+require "manageiq/providers/foreman"
 
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']


### PR DESCRIPTION
Adopt convention already supported by bundler and required by zeitwerk so we don't need to tell zeitwerk to ignore this lib/gem-name.rb file.