### PR TITLE
Drop require_nested and include_concern

### DIFF
--- a/app/models/manageiq/providers/foreman/configuration_manager.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager.rb
@@ -1,11 +1,4 @@
 class ManageIQ::Providers::Foreman::ConfigurationManager < ManageIQ::Providers::ConfigurationManager
-  require_nested :ConfigurationProfile
-  require_nested :ConfiguredSystem
-  require_nested :ProvisionTask
-  require_nested :ProvisionWorkflow
-  require_nested :Refresher
-  require_nested :RefreshWorker
-
   include ProcessTasksMixin
   delegate :authentication_check,
            :authentication_status,

--- a/app/models/manageiq/providers/foreman/configuration_manager/configured_system.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager/configured_system.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem < ::ConfiguredSystem
   include ProviderObjectMixin
-  include_concern 'Placement'
+  include Placement
 
   belongs_to :configuration_profile,
              :class_name => 'ManageIQ::Providers::Foreman::ConfigurationManager::ConfigurationProfile'

--- a/app/models/manageiq/providers/foreman/configuration_manager/provision_task.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager/provision_task.rb
@@ -1,6 +1,6 @@
 class ManageIQ::Providers::Foreman::ConfigurationManager::ProvisionTask < MiqProvisionTask
-  include_concern 'OptionsHelper'
-  include_concern 'StateMachine'
+  include OptionsHelper
+  include StateMachine
 
   def model_class
     ManageIQ::Providers::Foreman::ConfigurationManager::ConfiguredSystem

--- a/app/models/manageiq/providers/foreman/configuration_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/foreman/configuration_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Foreman::ConfigurationManager::RefreshWorker < MiqEmsRefreshWorker
-  require_nested :Runner
-
   def self.settings_name
     :ems_refresh_worker_foreman_configuration
   end

--- a/app/models/manageiq/providers/foreman/inventory.rb
+++ b/app/models/manageiq/providers/foreman/inventory.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::Foreman::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
 end

--- a/app/models/manageiq/providers/foreman/inventory/collector.rb
+++ b/app/models/manageiq/providers/foreman/inventory/collector.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::Foreman::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :Foreman
-  require_nested :ConfigurationManager
-  require_nested :ProvisioningManager
 end

--- a/app/models/manageiq/providers/foreman/inventory/parser.rb
+++ b/app/models/manageiq/providers/foreman/inventory/parser.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::Foreman::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :Foreman
-  require_nested :ConfigurationManager
-  require_nested :ProvisioningManager
 end

--- a/app/models/manageiq/providers/foreman/inventory/persister.rb
+++ b/app/models/manageiq/providers/foreman/inventory/persister.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::Foreman::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :Foreman
-  require_nested :ConfigurationManager
-  require_nested :ProvisioningManager
 end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854