### PR TITLE
Disable scheduled refresh for provision child manager

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,8 @@
 :ems_refresh:
   :foreman_configuration:
     :refresh_interval: 15.minutes
+  :foreman_provisioning:
+    :refresh_interval: 0
 :http_proxy:
   :foreman:
     :host:


### PR DESCRIPTION
Reasoning here: https://github.com/ManageIQ/manageiq-providers-azure/pull/564#issuecomment-2445034651

- provisioning manager `refresh_ems` is already delegated to the configuration manager, the refresh just needs to be disabled

@miq-bot assign @agrare
@miq-bot add_label bug, radjabov/yes?
@miq-bot add_reviewer @agrare